### PR TITLE
[BIG VISION]nborovenskiy/bug/bv 256 learner doesnot get email message for lti x block

### DIFF
--- a/lti_consumer/tasks.py
+++ b/lti_consumer/tasks.py
@@ -3,13 +3,16 @@ Defines asynchronous celery task for sending email notification (via EmailMultiA
 pertaining if a user got a grade in the LTI window, an email message sends for him
 """
 
-from celery import task
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
 from xblockutils.resources import ResourceLoader
 
+from lms import CELERY_APP
 
-@task
+ACE_ROUTING_KEY = getattr(settings, 'ACE_ROUTING_KEY', None)
+
+
+@CELERY_APP.task(name='lti_consumer.tasks.send_email_message', routing_key=ACE_ROUTING_KEY)
 def send_email_message(to_addr, subject, context):
     """
     Sends email with required context.


### PR DESCRIPTION
**Description:** Solving the problem when Celery tasks do not start in Production.

**Youtrack:** https://youtrack.raccoongang.com/issue/BV-256

**Reviewers:**
- @arsentur 
- @idegtiarov 

**Post merge:**
- [+] Delete working branch

**Author concerns:** Create release tag