### PR TITLE
[BIG VISION]nborovenskiy/enhancement/bv 278 lti consumer changes regarding customer feedback

### DIFF
--- a/lti_consumer/lti_consumer.py
+++ b/lti_consumer/lti_consumer.py
@@ -277,7 +277,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             docs_anchor_open=DOCS_ANCHOR_TAG_OPEN,
             anchor_close="</a>"
         ),
-        default='',
+        default="Vocareum_LTI_Course",
         scope=Scope.settings
     )
     launch_url = String(
@@ -313,7 +313,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             "Select New Window if you want the LTI content to open in a new browser window. "
             "This setting is only used when Hide External Tool is set to False."
         ),
-        default=LaunchTarget.IFRAME.value,
+        default=LaunchTarget.NEW_WINDOW.value,
         scope=Scope.settings,
         values=[
             {"display_name": LaunchTarget.IFRAME.display_name, "value": LaunchTarget.IFRAME.value},
@@ -364,7 +364,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
     has_score = Boolean(
         display_name=_("Scored"),
         help=_("Select True if this component will receive a numerical score from the external LTI system."),
-        default=False,
+        default=True,
         scope=Scope.settings
     )
     weight = Float(
@@ -411,14 +411,14 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         display_name=_("Request user's username"),
         # Translators: This is used to request the user's username for a third party service.
         help=_("Select True to request the user's username."),
-        default=False,
+        default=True,
         scope=Scope.settings
     )
     ask_to_send_email = Boolean(
         display_name=_("Request user's email"),
         # Translators: This is used to request the user's email for a third party service.
         help=_("Select True to request the user's email address."),
-        default=False,
+        default=True,
         scope=Scope.settings
     )
 
@@ -427,7 +427,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         help=_(
             "Send email notification when student earns a grade."
         ),
-        default=False,
+        default=True,
         scope=Scope.settings
     )
 

--- a/lti_consumer/outcomes.py
+++ b/lti_consumer/outcomes.py
@@ -8,7 +8,6 @@ https://www.imsglobal.org/specs/ltiomv1p0
 import logging
 import urllib
 
-from lxml import etree
 from xml.sax.saxutils import escape
 
 from django.conf import settings
@@ -200,7 +199,6 @@ class OutcomeService(object):
                 "platform_name": settings.PLATFORM_NAME,
                 "course_name": self.xblock.course.display_name,
                 "xblock_display_name": self.xblock.display_name,
-                "forum_link": settings.LMS_ROOT_URL + reverse('forum_form_discussion', args=[self.xblock.course_id]),
                 "xblock_url": settings.LMS_ROOT_URL + reverse(
                     'jump_to', args=[self.xblock.course_id, self.xblock.location]
                 ),

--- a/lti_consumer/templates/email/user_score_notification.html
+++ b/lti_consumer/templates/email/user_score_notification.html
@@ -95,7 +95,6 @@ from django.utils.translation import ugettext as _
                             </p>
                             <p style="color: rgba(0,0,0,.75);">
                                 Your Assignment: ${xblock_display_name} in course ${course_name} is reviewed.
-                                For questions or queries, check out the <a href="${forum_link}">discussion forum.</a>
                                 <br/>
                             </p>
                             <p>

--- a/lti_consumer/templates/email/user_score_notification.txt
+++ b/lti_consumer/templates/email/user_score_notification.txt
@@ -7,6 +7,5 @@ ${_("Review available")}
 Dear ${user_first_name if user_first_name else username}
 
 Your Assignment: ${xblock_display_name} in course ${course_name} is reviewed.
-For questions or queries, check out the discussion forum: ${forum_link}
 
 ${_("Go to project")}: ${xblock_url}


### PR DESCRIPTION
**Description:** LTI Consumer changes regarding customer feedback
- changed for LTI email body
- changed default values for the following settings:  LTI ID, LTI Launch Target, Scored, Request user’s username, Request user’s email, Enable Email Notification

**Youtrack:** https://youtrack.raccoongang.com/issue/BV-278

**Reviewers:**
- @arsentur 
- @idegtiarov 

**Post merge:**
- Delete working branch
- Make new tag. Version: `bigvision-v.1.1.14`

**DevOps Info**:
To achieve 1 option I suggest to make changes into settings stuff instead to do something with the codebase.
Go to lms.env.json and cms.env.json and change email from addresses.
e.g. old "DEFAULT_FROM_EMAIL": "courses@opencv.org"
new and desired one "DEFAULT_FROM_EMAIL": "OpenCV Courses <courses@opencv.org>"

Please consider the option of the change for rest email addresses to use one flow and be friendly for students.
