### PR TITLE
Extend LTI xblock with possibility to send user's full name

### DIFF
--- a/lti_consumer/lti.py
+++ b/lti_consumer/lti.py
@@ -149,6 +149,7 @@ class LtiConsumer(object):
         self.xblock.user_email = ""
         self.xblock.user_username = ""
         self.xblock.user_language = ""
+        self.xblock.user_fullname = ""
 
         # Username, email, and language can't be sent in studio mode, because the user object is not defined.
         # To test functionality test in LMS
@@ -157,6 +158,11 @@ class LtiConsumer(object):
             real_user_object = self.xblock.runtime.get_real_user(self.xblock.runtime.anonymous_student_id)
             self.xblock.user_email = getattr(real_user_object, "email", "")
             self.xblock.user_username = getattr(real_user_object, "username", "")
+
+            first_name = getattr(real_user_object, "first_name", "")
+            last_name = getattr(real_user_object, "last_name", "")
+            self.xblock.user_fullname = '{} {}'.format(first_name, last_name).strip() or self.xblock.user_username
+
             user_preferences = getattr(real_user_object, "preferences", None)
 
             if user_preferences is not None:
@@ -168,6 +174,8 @@ class LtiConsumer(object):
             lti_parameters["lis_person_sourcedid"] = self.xblock.user_username
         if self.xblock.ask_to_send_email and self.xblock.user_email:
             lti_parameters["lis_person_contact_email_primary"] = self.xblock.user_email
+        if self.xblock.ask_to_send_full_name and self.xblock.user_fullname:
+            lti_parameters["lis_person_name_full"] = self.xblock.user_fullname
         if self.xblock.user_language:
             lti_parameters["launch_presentation_locale"] = self.xblock.user_language
 

--- a/lti_consumer/lti_consumer.py
+++ b/lti_consumer/lti_consumer.py
@@ -422,12 +422,20 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         scope=Scope.settings
     )
 
+    ask_to_send_full_name = Boolean(
+        display_name=_("Request user's full name"),
+        # Translators: This is used to request the user's full nam for a third party service.
+        help=_("Select True to request the user's full name."),
+        default=False,
+        scope=Scope.settings
+    )
+
     # Possible editable fields
     editable_field_names = (
         'display_name', 'description', 'lti_id', 'launch_url', 'custom_parameters',
         'launch_target', 'button_text', 'inline_height', 'modal_height', 'modal_width',
         'has_score', 'weight', 'hide_launch', 'accept_grades_past_due', 'ask_to_send_username',
-        'ask_to_send_email'
+        'ask_to_send_email', 'ask_to_send_full_name'
     )
 
     def validate_field_data(self, validation, data):
@@ -438,26 +446,12 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
     @property
     def editable_fields(self):
         """
-        Returns editable fields which may/may not contain 'ask_to_send_username' and
-        'ask_to_send_email' fields depending on the configuration service.
-        """
-        editable_fields = self.editable_field_names
-        # update the editable fields if this XBlock is configured to not to allow the
-        # editing of 'ask_to_send_username' and 'ask_to_send_email'.
-        config_service = self.runtime.service(self, 'lti-configuration')
-        if config_service:
-            is_already_sharing_learner_info = self.ask_to_send_email or self.ask_to_send_username
-            if not config_service.configuration.lti_access_to_learners_editable(
-                    self.course_id,
-                    is_already_sharing_learner_info,
-            ):
-                editable_fields = tuple(
-                    field
-                    for field in self.editable_field_names
-                    if field not in ('ask_to_send_username', 'ask_to_send_email')
-                )
+        Returns editable fields.
 
-        return editable_fields
+        Editable fields may/may not contain 'ask_to_send_username', 'ask_to_send_email' and 'ask_to_send_full_name'
+        fields depending on the configuration service.
+        """
+        return self.editable_field_names
 
     @property
     def descriptor(self):
@@ -879,6 +873,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             'description': self.description,
             'ask_to_send_username': self.ask_to_send_username,
             'ask_to_send_email': self.ask_to_send_email,
+            'ask_to_send_full_name': self.ask_to_send_full_name,
             'button_text': self.button_text,
             'inline_height': self.inline_height,
             'modal_vertical_offset': self._get_modal_position_offset(self.modal_height),

--- a/lti_consumer/static/js/xblock_lti_consumer.js
+++ b/lti_consumer/static/js/xblock_lti_consumer.js
@@ -78,6 +78,7 @@ function LtiConsumerXBlock(runtime, element) {
         var $ltiContainer = $element.find('.lti-consumer-container');
         var askToSendUsername = $ltiContainer.data('ask-to-send-username') == 'True';
         var askToSendEmail = $ltiContainer.data('ask-to-send-email') == 'True';
+        var askToSendFullName = $ltiContainer.data('ask-to-send-full-name') == 'True';
 
         // Apply click handler to modal launch button
         $element.find('.btn-lti-modal').iframeModal({top: 200, closeButton: '.close-modal'});
@@ -88,12 +89,20 @@ function LtiConsumerXBlock(runtime, element) {
 
             // If this instance is configured to require username and/or email, ask user if it is okay to send them
             // Do not launch if it is not okay
-            if(askToSendUsername && askToSendEmail) {
+            if(askToSendUsername && askToSendEmail && askToSendFullName) {
+                launch = confirm(gettext("Click OK to have your username, e-mail address and full name sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information."));
+            } else if(askToSendUsername && askToSendEmail) {
                 launch = confirm(gettext("Click OK to have your username and e-mail address sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information."));
+            } else if (askToSendUsername && askToSendFullName) {
+                launch = confirm(gettext("Click OK to have your username and full name sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information."));
+            } else if (askToSendEmail && askToSendFullName) {
+                launch = confirm(gettext("Click OK to have your e-mail and full name sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information."));
             } else if (askToSendUsername) {
                 launch = confirm(gettext("Click OK to have your username sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information."));
             } else if (askToSendEmail) {
                 launch = confirm(gettext("Click OK to have your e-mail address sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information."));
+            } else if (askToSendFullName) {
+                launch = confirm(gettext("Click OK to have your full name sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information."));
             }
 
             if (launch) {

--- a/lti_consumer/templates/html/student.html
+++ b/lti_consumer/templates/html/student.html
@@ -18,6 +18,7 @@
     class="${element_class} lti-consumer-container"
     data-ask-to-send-username="${ask_to_send_username}"
     data-ask-to-send-email="${ask_to_send_email}"
+    data-ask-to-send-full-name="${ask_to_send_full_name}"
 >
 
 % if launch_url and not hide_launch:

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def package_data(pkg, roots):
 
 setup(
     name='lti_consumer-xblock',
-    version='1.1.8',
+    version='kscdr-1.1.8',
     description='This XBlock implements the consumer side of the LTI specification.',
     packages=[
         'lti_consumer',


### PR DESCRIPTION
**Description:** I've replaced the commit with solution: https://github.com/raccoongang/xblock-lti-consumer/commit/b1f2084036863ec76b0b7c233344a33a6564ca73

**Description from commit:**
New field `ask_to_send_full_name` is added to the xblock settings, it
becomes available in case `lti fields enabled flag` is enabled
in the studio admin.

*Task:* https://youtrack.raccoongang.com/issue/EsenseKSCDR-232