### PR TITLE
BV-629: The task import was relocated into a method.

### DIFF
--- a/lti_consumer/outcomes.py
+++ b/lti_consumer/outcomes.py
@@ -17,7 +17,6 @@ from xblockutils.resources import ResourceLoader
 
 from .exceptions import LtiError
 from .oauth import verify_oauth_body_signature
-from .tasks import send_email_message
 
 log = logging.getLogger(__name__)
 
@@ -192,6 +191,7 @@ class OutcomeService(object):
 
         # Sends an email when the user earns a grade if xblock setting "email_notifications" is enabled.
         if self.xblock.email_notifications:
+            from .tasks import send_email_message  # Import here since this is edX LMS specific
             context = {
                 "username": real_user.username,
                 "user_first_name": real_user.first_name,

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def package_data(pkg, roots):
 
 setup(
     name='lti_consumer-xblock',
-    version='1.1.9',
+    version='1.1.10',
     description='This XBlock implements the consumer side of the LTI specification.',
     packages=[
         'lti_consumer',


### PR DESCRIPTION
**Description:**
Fixed problem with sending emails. For that:

The task import was relocated into the method where it's used. It's necessary for working CELERY_IMPORTS functionality.  

**Tasks:**
https://youtrack.raccoongang.com/issue/BV-629

**The demo was shown**