### PR TITLE
feat: [Tanuki-560] add full name as a LTI PII field

### DIFF
--- a/lti_consumer/lti_1p1/consumer.py
+++ b/lti_consumer/lti_1p1/consumer.py
@@ -155,7 +155,8 @@ class LtiConsumer1p1:
             roles,
             result_sourcedid,
             person_sourcedid=None,
-            person_contact_email_primary=None
+            person_contact_email_primary=None,
+            person_name_full=None,
     ):
         """
         Set user data/roles
@@ -167,6 +168,7 @@ class LtiConsumer1p1:
                 and uniquely identifies a row and column within the Tool Consumer gradebook
             person_sourcedid (string):  LIS identifier for the user account performing the launch
             person_contact_email_primary (string):  Primary contact email address of the user
+            person_name_full (string): Full name of the user
         """
         self.lti_user_data = {
             'user_id': user_id,
@@ -184,6 +186,11 @@ class LtiConsumer1p1:
         if person_contact_email_primary:
             self.lti_user_data.update({
                 'lis_person_contact_email_primary': person_contact_email_primary,
+            })
+
+        if person_name_full:
+            self.lti_user_data.update({
+                'lis_person_name_full': person_name_full,
             })
 
     def set_context_data(self, context_id, context_title, context_label):

--- a/lti_consumer/lti_1p1/tests/test_consumer.py
+++ b/lti_consumer/lti_1p1/tests/test_consumer.py
@@ -193,6 +193,7 @@ class TestLtiConsumer1p1(unittest.TestCase):
         roles = 'roles'
         result_sourcedid = 'result_sourcedid'
         person_sourcedid = 'person_sourcedid'
+        person_name_full = 'person_name_full'
         person_contact_email_primary = 'person_contact_email_primary'
         context_id = 'context_id'
         context_title = 'context_title'
@@ -210,7 +211,8 @@ class TestLtiConsumer1p1(unittest.TestCase):
             roles,
             result_sourcedid,
             person_sourcedid=person_sourcedid,
-            person_contact_email_primary=person_contact_email_primary
+            person_contact_email_primary=person_contact_email_primary,
+            person_name_full=person_name_full,
         )
         self.lti_consumer.set_context_data(context_id, context_title, context_label)
         self.lti_consumer.set_outcome_service_url(outcome_service_url)
@@ -229,6 +231,7 @@ class TestLtiConsumer1p1(unittest.TestCase):
             'lis_result_sourcedid': result_sourcedid,
             'lis_person_sourcedid': person_sourcedid,
             'lis_person_contact_email_primary': person_contact_email_primary,
+            'lis_person_name_full': person_name_full,
             'context_id': context_id,
             'context_label': context_label,
             'context_title': context_title,

--- a/lti_consumer/static/js/xblock_lti_consumer.js
+++ b/lti_consumer/static/js/xblock_lti_consumer.js
@@ -95,6 +95,7 @@ function LtiConsumerXBlock(runtime, element) {
         var $element = $(element);
         var $ltiContainer = $element.find('.lti-consumer-container');
         var askToSendUsername = $ltiContainer.data('ask-to-send-username') == 'True';
+        var askToSendFullName = $ltiContainer.data('ask-to-send-full-name') == 'True';
         var askToSendEmail = $ltiContainer.data('ask-to-send-email') == 'True';
 
         // Apply click handler to modal launch button
@@ -138,12 +139,20 @@ function LtiConsumerXBlock(runtime, element) {
                 return def.promise();
               };
 
-            if(askToSendUsername && askToSendEmail) {
+            if (askToSendUsername && askToSendFullName && askToSendEmail) {
+                msg = gettext("Click OK to have your username, full name, and e-mail address sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information.");
+            } else if(askToSendUsername && askToSendEmail) {
                 msg = gettext("Click OK to have your username and e-mail address sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information.");
+            } else if (askToSendUsername && askToSendFullName) {
+                msg = gettext("Click OK to have your username and full name sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information.");
+            } else if (askToSendFullName && askToSendEmail) {
+                msg = gettext("Click OK to have your full name and e-mail address sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information.");
             } else if (askToSendUsername) {
                 msg = gettext("Click OK to have your username sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information.");
             } else if (askToSendEmail) {
                 msg = gettext("Click OK to have your e-mail address sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information.");
+            } else if (askToSendFullName) {
+                msg = gettext("Click OK to have your full name sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information.");
             } else {
                 window.open(destination);
             }

--- a/lti_consumer/templates/html/student.html
+++ b/lti_consumer/templates/html/student.html
@@ -17,6 +17,7 @@
     id="${element_id}"
     class="${element_class} lti-consumer-container"
     data-ask-to-send-username="${ask_to_send_username}"
+    data-ask-to-send-full-name="${ask_to_send_full_name}"
     data-ask-to-send-email="${ask_to_send_email}"
 >
 

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -429,8 +429,8 @@ class TestEditableFields(TestLtiConsumerXBlock):
         Returns a mock object of lti-configuration service
 
         Arguments:
-            editable (bool): This indicates whether the LTI fields (i.e. 'ask_to_send_username' and
-            'ask_to_send_email') are editable.
+            editable (bool): This indicates whether the LTI fields (i.e. 'ask_to_send_username', 'ask_to_send_full_name',
+            and 'ask_to_send_email') are editable.
         """
         lti_configuration = Mock()
         lti_configuration.configuration = Mock()
@@ -450,32 +450,35 @@ class TestEditableFields(TestLtiConsumerXBlock):
 
     def test_editable_fields_with_no_config(self):
         """
-        Test that LTI XBlock's fields (i.e. 'ask_to_send_username' and 'ask_to_send_email')
-        are editable when lti-configuration service is not provided.
+        Test that LTI XBlock's fields (i.e. 'ask_to_send_username', 'ask_to_send_full_name', and 'ask_to_send_email')
         """
         self.xblock.runtime.service.return_value = None
-        # Assert that 'ask_to_send_username' and 'ask_to_send_email' are editable.
-        self.assertTrue(self.are_fields_editable(fields=['ask_to_send_username', 'ask_to_send_email']))
+        # Assert that 'ask_to_send_username', 'ask_to_send_full_name', and 'ask_to_send_email' are editable.
+        self.assertTrue(
+            self.are_fields_editable(fields=['ask_to_send_username', 'ask_to_send_full_name', 'ask_to_send_email'])
+        )
 
     def test_editable_fields_when_editing_allowed(self):
         """
-        Test that LTI XBlock's fields (i.e. 'ask_to_send_username' and 'ask_to_send_email')
-        are editable when this XBlock is configured to allow it.
+        Test that LTI XBlock's fields (i.e. 'ask_to_send_username', 'ask_to_send_full_name', and 'ask_to_send_email')
         """
         # this XBlock is configured to allow editing of LTI fields
         self.xblock.runtime.service.return_value = self.get_mock_lti_configuration(editable=True)
-        # Assert that 'ask_to_send_username' and 'ask_to_send_email' are editable.
-        self.assertTrue(self.are_fields_editable(fields=['ask_to_send_username', 'ask_to_send_email']))
+        # Assert that 'ask_to_send_username', 'ask_to_send_full_name', and 'ask_to_send_email' are editable.
+        self.assertTrue(
+            self.are_fields_editable(fields=['ask_to_send_username', 'ask_to_send_full_name', 'ask_to_send_email'])
+        )
 
     def test_editable_fields_when_editing_not_allowed(self):
         """
-        Test that LTI XBlock's fields (i.e. 'ask_to_send_username' and 'ask_to_send_email')
-        are not editable when this XBlock is configured to not to allow it.
+        Test that LTI XBlock's fields (i.e. 'ask_to_send_username', 'ask_to_send_full_name', and 'ask_to_send_email')
         """
         # this XBlock is configured to not to allow editing of LTI fields
         self.xblock.runtime.service.return_value = self.get_mock_lti_configuration(editable=False)
-        # Assert that 'ask_to_send_username' and 'ask_to_send_email' are not editable.
-        self.assertFalse(self.are_fields_editable(fields=['ask_to_send_username', 'ask_to_send_email']))
+        # Assert that 'ask_to_send_username', 'ask_to_send_full_name', and 'ask_to_send_email' are not editable.
+        self.assertFalse(
+            self.are_fields_editable(fields=['ask_to_send_username', 'ask_to_send_full_name', 'ask_to_send_email'])
+        )
 
     def test_lti_1p3_fields_appear(self):
         """
@@ -545,6 +548,10 @@ class TestExtractRealUserData(TestLtiConsumerXBlock):
         fake_user = Mock()
         fake_user_email = 'abc@example.com'
         fake_user.emails = [fake_user_email]
+
+        full_name_mock = PropertyMock(return_value='fake_full_name')
+        type(fake_user).full_name = full_name_mock
+
         fake_username = 'fake'
         fake_user.opt_attrs = {
             "edx-platform.username": fake_username
@@ -686,6 +693,10 @@ class TestLtiLaunchHandler(TestLtiConsumerXBlock):
         fake_user = Mock()
         fake_user_email = 'abc@example.com'
         fake_user.emails = [fake_user_email]
+
+        full_name_mock = PropertyMock(return_value='fake_full_name')
+        type(fake_user).full_name = full_name_mock
+
         fake_username = 'fake'
         fake_user.opt_attrs = {
             "edx-platform.username": fake_username


### PR DESCRIPTION
This commits adds the ability to share a learner's full name in both LTI 1.1 and LTI 1.3 launches. In LTI 1.1, the full name is sent as the "lis_person_name_full" LTI parameter.

The full name corresponds to the learner's name as recorded by the UserProfile model in the LMS.

Enabling the transmission of full name in either version of LTI follows the existing pattern for PII sharing. In order for full name to be shared via an LTI launch, the
CourseAllowPIISharingInLTIFlag configuration model must be enabled for the course, and the "Request user's full name" XBlock field must be enabled in the XBlock describing the particular LTI integration.

Please note that this commit does not add the ability to share a learner's full name via the LTI 1.3 Names and Role Provisioning Services context membership endpoint because that behavior already exists.