### PR TITLE
Revert "fix: [CO-7] fix lti launch url on external"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,10 +16,6 @@ Please See the `releases tab <https://github.com/openedx/xblock-lti-consumer/rel
 Unreleased
 ~~~~~~~~~~
 
-9.13.1 - 2025-02-26
--------------------
-* Fixed taken lti launch url for external LTI configurations.
-
 9.13.0 - 2025-02-25
 -------------------
 * Added ability to override launch URL on block for external LTI configurations.

--- a/lti_consumer/__init__.py
+++ b/lti_consumer/__init__.py
@@ -4,4 +4,4 @@ Runtime will load the XBlock class from here.
 from .apps import LTIConsumerApp
 from .lti_xblock import LtiConsumerXBlock
 
-__version__ = '9.13.1'
+__version__ = '9.13.0'

--- a/lti_consumer/models.py
+++ b/lti_consumer/models.py
@@ -589,7 +589,7 @@ class LtiConfiguration(models.Model):
             consumer = consumer_class(
                 iss=get_lti_api_base(),
                 lti_oidc_url=self.external_config.get('lti_1p3_oidc_url'),
-                lti_launch_url=block.lti_1p3_launch_url or self.external_config.get('lti_1p3_launch_url'),
+                lti_launch_url=self.lti_1p3_launch_url or self.external_config.get('lti_1p3_launch_url'),
                 client_id=self.external_config.get('lti_1p3_client_id'),
                 # Deployment ID hardcoded to 1 since
                 # we're not using multi-tenancy.


### PR DESCRIPTION
Reverts raccoongang/xblock-lti-consumer#18