### PR TITLE
feat: [CSC-30] on config external don't hide launch url if flag enabled

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,12 @@ Please See the `releases tab <https://github.com/openedx/xblock-lti-consumer/rel
 Unreleased
 ~~~~~~~~~~
 
+9.13.5 - 2025-04-04
+-------------------
+* Add new flag `lti_consumer.enable_external_multiple_launch_urls`.
+* Update logic for retrieving `lti_1p3_launch_url` from `LtiConfiguration` model.
+* Make `lti_1p3_launch_url` field visible in studio settings when the feature course flag is enabled.
+
 9.13.4 - 2025-03-21
 -------------------
 * fix: update tests after pyjwt version upgrade

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -86,6 +86,7 @@ from .utils import (
     external_user_id_1p1_launches_enabled,
     database_config_enabled,
     EXTERNAL_ID_REGEX,
+    external_multiple_launch_urls_enabled,
 )
 
 log = logging.getLogger(__name__)
@@ -1184,7 +1185,12 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         fragment = super().studio_view(context)
 
         fragment.add_javascript(loader.load_unicode("static/js/xblock_studio_view.js"))
-        fragment.initialize_js('LtiConsumerXBlockInitStudio')
+        js_context = {
+            "EXTERNAL_MULTIPLE_LAUNCH_URLS_ENABLED": external_multiple_launch_urls_enabled(
+                self.scope_ids.usage_id.course_key
+            )
+        }
+        fragment.initialize_js('LtiConsumerXBlockInitStudio', js_context)
 
         return fragment
 

--- a/lti_consumer/plugin/compat.py
+++ b/lti_consumer/plugin/compat.py
@@ -93,7 +93,7 @@ def get_database_config_waffle_flag():
 
 def get_external_multiple_launch_urls_waffle_flag():
     """
-    Import and return Waffle flag for enabling multiple external launch URLs in LTI configurations.
+    Import and return Waffle flag for enabling multiple launch URLs with the external LTI configurations.
     """
     # pylint: disable=import-error,import-outside-toplevel
     from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag

--- a/lti_consumer/plugin/compat.py
+++ b/lti_consumer/plugin/compat.py
@@ -56,6 +56,16 @@ ENABLE_EXTERNAL_USER_ID_1P1_LAUNCHES = 'enable_external_user_id_1p1_launches'
 # .. toggle_warning: None.
 ENABLE_DATABASE_CONFIG = 'enable_database_config'
 
+# .. toggle_name: lti_consumer.enable_external_multiple_launch_urls
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Enables support for multiple external launch URLs in LTI configurations.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2025-04-04
+# .. toggle_tickets: None
+# .. toggle_warning: None.
+ENABLE_EXTERNAL_MULTIPLE_LAUNCH_URLS = 'enable_external_multiple_launch_urls'
+
 
 def get_external_config_waffle_flag():
     """
@@ -79,6 +89,15 @@ def get_database_config_waffle_flag():
     # pylint: disable=import-error,import-outside-toplevel
     from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
     return CourseWaffleFlag(f'{WAFFLE_NAMESPACE}.{ENABLE_DATABASE_CONFIG}', __name__)
+
+
+def get_external_multiple_launch_urls_waffle_flag():
+    """
+    Import and return Waffle flag for enabling multiple external launch URLs in LTI configurations.
+    """
+    # pylint: disable=import-error,import-outside-toplevel
+    from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
+    return CourseWaffleFlag(f'{WAFFLE_NAMESPACE}.{ENABLE_EXTERNAL_MULTIPLE_LAUNCH_URLS}', __name__)
 
 
 def load_enough_xblock(location):  # pragma: nocover

--- a/lti_consumer/static/js/xblock_studio_view.js
+++ b/lti_consumer/static/js/xblock_studio_view.js
@@ -85,7 +85,8 @@ function LtiConsumerXBlockInitStudio(runtime, element, data) {
             externalConfigHiddenFields.forEach(function (field) {
                 fieldsToHide.push(field);
             })
-            if(data.EXTERNAL_MULTIPLE_LAUNCH_URLS_ENABLED) {
+            // Conditionally show the LTI 1.3 launch URL field if external multiple launch URLs are enabled.
+            if (data.EXTERNAL_MULTIPLE_LAUNCH_URLS_ENABLED) {
                 const index = fieldsToHide.indexOf("lti_1p3_launch_url");
                 if (index > -1) {
                     fieldsToHide.splice(index, 1);

--- a/lti_consumer/static/js/xblock_studio_view.js
+++ b/lti_consumer/static/js/xblock_studio_view.js
@@ -1,7 +1,7 @@
 /**
  * Javascript for LTI Consumer Studio View.
 */
-function LtiConsumerXBlockInitStudio(runtime, element) {
+function LtiConsumerXBlockInitStudio(runtime, element, data) {
     // Run parent function to set up studio view base JS
     StudioEditableXBlockMixin(runtime, element);
 
@@ -85,6 +85,12 @@ function LtiConsumerXBlockInitStudio(runtime, element) {
             externalConfigHiddenFields.forEach(function (field) {
                 fieldsToHide.push(field);
             })
+            if(data.EXTERNAL_MULTIPLE_LAUNCH_URLS_ENABLED) {
+                const index = fieldsToHide.indexOf("lti_1p3_launch_url");
+                if (index > -1) {
+                    fieldsToHide.splice(index, 1);
+                }
+            }
         } else if (configType === "database") {
             // Hide the LTI 1.1 and LTI 1.3 fields. The XBlock will remain the source of truth for the lti_version,
             // so do not hide it and continue to allow editing it from the XBlock edit menu in Studio.

--- a/lti_consumer/tests/unit/test_lti_xblock.py
+++ b/lti_consumer/tests/unit/test_lti_xblock.py
@@ -1783,10 +1783,15 @@ class TestLtiConsumer1p3XBlock(TestCase):
 
         self.mock_filter_enabled_patcher = patch("lti_consumer.lti_xblock.external_config_filter_enabled")
         self.mock_database_config_enabled_patcher = patch("lti_consumer.lti_xblock.database_config_enabled")
+        self.mock_external_multiple_launch_urls_enabled = patch(
+            "lti_consumer.lti_xblock.external_multiple_launch_urls_enabled"
+        )
         self.mock_filter_enabled = self.mock_filter_enabled_patcher.start()
         self.mock_database_config_enabled = self.mock_database_config_enabled_patcher.start()
+        self.mock_external_multiple_launch_urls_enabled.start()
         self.addCleanup(self.mock_filter_enabled_patcher.stop)
         self.addCleanup(self.mock_database_config_enabled_patcher.stop)
+        self.addCleanup(self.mock_external_multiple_launch_urls_enabled.stop)
 
     @patch.object(LtiConsumerXBlock, 'get_parameter_processors')
     @patch('lti_consumer.lti_xblock.resolve_custom_parameter_template')

--- a/lti_consumer/tests/unit/test_models.py
+++ b/lti_consumer/tests/unit/test_models.py
@@ -545,8 +545,11 @@ class TestLtiConfigurationModel(TestCase):
         filter_mock
     ):
         """
-        Test that the external LTI consumer returns the launch URL from the block
-        if the external_multiple_launch_urls_enabled flag is set to True.
+        Verify that the external LTI consumer uses the block's launch URL when multiple launch URLs are enabled.
+
+        When the `external_multiple_launch_urls_enabled` flag is True, the consumer's
+        `launch_url` should be set to the `lti_1p3_launch_ur`l` from the loaded block rather than
+        the default URL provided by the external configuration.
         """
         external_multiple_launch_urls_enabled.return_value = True
         filter_mock.return_value = {

--- a/lti_consumer/tests/unit/test_models.py
+++ b/lti_consumer/tests/unit/test_models.py
@@ -77,6 +77,7 @@ class TestLtiConfigurationModel(TestCase):
         self.lti_1p3_config_external = LtiConfiguration.objects.create(
             version=LtiConfiguration.LTI_1P3,
             config_store=LtiConfiguration.CONFIG_EXTERNAL,
+            location=self.xblock.scope_ids.usage_id,
         )
 
         self.lti_1p1_external = LtiConfiguration.objects.create(
@@ -154,11 +155,13 @@ class TestLtiConfigurationModel(TestCase):
         LtiConfiguration.CONFIG_EXTERNAL,
     )
     @patch('lti_consumer.models.get_external_config_from_filter')
-    def test_lti_consumer_ags_enabled(self, config_store, filter_mock):
+    @patch('lti_consumer.models.external_multiple_launch_urls_enabled')
+    def test_lti_consumer_ags_enabled(self, config_store, external_multiple_launch_urls_enabled_mock, filter_mock):
         """
         Check if LTI AGS is properly included when block is graded.
         """
         filter_mock.return_value = {'lti_advantage_ags_mode': 'programmatic'}
+        external_multiple_launch_urls_enabled_mock.return_value = False
         config = self._get_1p3_config(
             config_store=config_store,
             lti_advantage_ags_mode='programmatic'
@@ -207,10 +210,12 @@ class TestLtiConfigurationModel(TestCase):
         LtiConfiguration.CONFIG_EXTERNAL,
     )
     @patch('lti_consumer.models.get_external_config_from_filter')
-    def test_lti_consumer_ags_declarative(self, config_store, filter_mock):
+    @patch('lti_consumer.models.external_multiple_launch_urls_enabled')
+    def test_lti_consumer_ags_declarative(self, config_store, external_multiple_launch_urls_enabled, filter_mock):
         """
         Check that a LineItem is created if AGS is set to the declarative mode.
         """
+        external_multiple_launch_urls_enabled.return_value = False
         filter_mock.return_value = {'lti_advantage_ags_mode': 'declarative'}
         self.xblock.lti_advantage_ags_mode = 'declarative'
 
@@ -246,11 +251,13 @@ class TestLtiConfigurationModel(TestCase):
         LtiConfiguration.CONFIG_EXTERNAL,
     )
     @patch('lti_consumer.models.get_external_config_from_filter')
-    def test_lti_consumer_deep_linking_enabled(self, config_store, filter_mock):
+    @patch('lti_consumer.models.external_multiple_launch_urls_enabled')
+    def test_lti_consumer_deep_linking_enabled(self, config_store, external_multiple_launch_urls_enabled, filter_mock):
         """
         Check if LTI DL is properly instanced when configured.
         """
         filter_mock.return_value = {'lti_advantage_deep_linking_enabled': True}
+        external_multiple_launch_urls_enabled.return_value = False
         config = self._get_1p3_config(
             config_store=config_store,
             lti_advantage_deep_linking_enabled=True
@@ -529,6 +536,24 @@ class TestLtiConfigurationModel(TestCase):
             f'Failed to query children CCX LTI configurations: '
             f'Failed to parse main LTI configuration location: {self.lti_1p3_config.location}'
         )
+
+    @patch('lti_consumer.models.get_external_config_from_filter')
+    @patch('lti_consumer.models.external_multiple_launch_urls_enabled')
+    def test_external_lti_consumer_1p3_returns_launch_url_from_block(
+        self,
+        external_multiple_launch_urls_enabled,
+        filter_mock
+    ):
+        """
+        Test that the external LTI consumer returns the launch URL from the block
+        if the external_multiple_launch_urls_enabled flag is set to True.
+        """
+        external_multiple_launch_urls_enabled.return_value = True
+        filter_mock.return_value = {
+            'lti_1p3_launch_url': 'http://launch-url-from-config.example/launch',
+        }
+        consumer = self.lti_1p3_config_external.get_lti_consumer()
+        self.assertEqual(consumer.launch_url, self.xblock.lti_1p3_launch_url)
 
 
 class TestLtiAgsLineItemModel(TestCase):

--- a/lti_consumer/utils.py
+++ b/lti_consumer/utils.py
@@ -14,6 +14,7 @@ from lti_consumer.plugin.compat import (
     get_external_config_waffle_flag,
     get_external_user_id_1p1_launches_waffle_flag,
     get_database_config_waffle_flag,
+    get_external_multiple_launch_urls_waffle_flag,
 )
 from lti_consumer.lti_1p3.constants import LTI_1P3_CONTEXT_TYPE
 from lti_consumer.lti_1p3.exceptions import InvalidClaimValue, MissingRequiredClaim
@@ -228,6 +229,14 @@ def database_config_enabled(course_key):
     return False if it is not enabled.
     """
     return get_database_config_waffle_flag().is_enabled(course_key)
+
+
+def external_multiple_launch_urls_enabled(course_key):
+    """
+    Return whether the lti_consumer.enable_external_multiple_launch_urls WaffleFlag is enabled. Return True if it is
+    enabled; return False if it is not enabled.
+    """
+    return get_external_multiple_launch_urls_waffle_flag().is_enabled(course_key)
 
 
 def get_lti_1p3_context_types_claim(context_types):

--- a/lti_consumer/utils.py
+++ b/lti_consumer/utils.py
@@ -233,8 +233,13 @@ def database_config_enabled(course_key):
 
 def external_multiple_launch_urls_enabled(course_key):
     """
-    Return whether the lti_consumer.enable_external_multiple_launch_urls WaffleFlag is enabled. Return True if it is
+    Check if the external multiple launch URLs feature is enabled.
+
+    Return whether the `lti_consumer.enable_external_multiple_launch_urls WaffleFlag` is enabled. Return True if it is
     enabled; return False if it is not enabled.
+
+    Arguments:
+        course_key (opaque_keys.edx.locator.CourseLocator): Course Key
     """
     return get_external_multiple_launch_urls_waffle_flag().is_enabled(course_key)
 


### PR DESCRIPTION
**Ticket:** https://youtrack.raccoongang.com/issue/CSC-30/Backport-LTI-Improvements-to-the-Upstream
**Description:**
- Added new course waffle flag `lti_consumer.enable_external_multiple_launch_urls`
- Updated logic for retrieving `lti_1p3_launch_url` from the `LtiConfiguration` model: if the feature flag is enabled and the block's `lti_1p3_launch_url` is provided, it will be used; otherwise, the value from the external configuration will be used.
- Made `lti_1p3_launch_url` field visible in studio settings when the feature course flag is enabled.